### PR TITLE
Do not enable any features by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,7 @@ pin-utils = { version = "0.1.0", optional = true }
 memoffset = { version = "0.9", optional = true }
 
 [features]
-default = [
-  "acct", "aio", "dir", "env", "event", "feature", "fs",
-  "hostname", "inotify", "ioctl", "kmod", "mman", "mount", "mqueue",
-  "net", "personality", "poll", "process", "pthread", "ptrace", "quota",
-  "reboot", "resource", "sched", "signal", "socket", "term", "time",
-  "ucontext", "uio", "user", "zerocopy",
-]
+default = []
 
 acct = []
 aio = ["pin-utils"]


### PR DESCRIPTION
The original intention behind https://github.com/nix-rust/nix/pull/1498 was to allow repositories to slim down what amount of nix they consume, saving on compile time. However, with all these features enabled by default, it only takes one crate in your entire dependency tree that doesn't set `default-features = false` and suddenly you're back to square one. The better solution IMHO would be to always require crates to opt in to the functionality they need, ensuring that this footgun can't fire.

This is a breaking change, and would need a new version number before release.